### PR TITLE
Add trace logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The first module extracted is **rundown protection**, which wraps the Windows `E
 | `ebpf_ext_enter_rundown` | Acquire rundown protection (returns `false` if rundown already occurred) |
 | `ebpf_ext_leave_rundown` | Release previously acquired rundown protection |
 
+### Trace Logging
+
+The library includes a structured ETW trace logging framework built on `TraceLoggingProvider.h`. It provides a set of macros for emitting diagnostics at various levels (log, verbose, info, warning, error) with support for extension-specific keywords.
+
+See [docs/tracing.md](docs/tracing.md) for the design rationale, macro reference, and a step-by-step guide for adding new keywords.
+
 ## Prerequisites
 
 - **Visual Studio 2022** (v143 toolset)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,160 @@
+# Trace Logging
+
+This library provides a common trace logging infrastructure for eBPF extension
+drivers. Consumers provide their own TraceLogging provider; the library supplies
+macros, dispatch functions, and registration/teardown logic.
+
+## Design: Why switch dispatch instead of inline macros
+
+`TraceLoggingWrite` requires keyword and level arguments to be **compile-time
+constants**. A straightforward macro-only approach would inline the full
+`TraceLoggingWrite` expansion (~200-300 bytes of machine code) at every call
+site. For a driver with many trace points, this adds up quickly.
+
+To keep binary size small, the public logging macros (e.g.,
+`EBPF_EXT_LOG_MESSAGE`) route through helper functions in
+`ebpf_ext_tracelog.c`. These functions use `switch` statements to convert
+runtime enum values back into the compile-time constants that
+`TraceLoggingWrite` needs. Each keyword/level combination appears exactly once
+in the switch body, so the `TraceLoggingWrite` metadata is emitted once per
+variant rather than once per call site.
+
+The tradeoff is that adding a new keyword requires updating three places (see
+below). This is intentional — it keeps the dispatch centralized and the binary
+compact.
+
+## Setup
+
+### 1. Define a TraceLogging provider
+
+In exactly one source file in your extension, define the provider with your
+own name and GUID:
+
+```c
+#include "ebpf_ext_tracelog.h"
+
+TRACELOGGING_DEFINE_PROVIDER(
+    ebpf_ext_tracelog_provider,
+    "MyExtensionProvider",
+    // {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+    (0x12345678, 0xabcd, 0xef01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01));
+```
+
+### 2. Register and unregister the provider
+
+Call `ebpf_ext_trace_initiate()` during driver/module initialization and
+`ebpf_ext_trace_terminate()` during teardown:
+
+```c
+NTSTATUS DriverEntry(...)
+{
+    NTSTATUS status = ebpf_ext_trace_initiate();
+    if (!NT_SUCCESS(status)) {
+        return status;
+    }
+    // ...
+}
+
+void DriverUnload(...)
+{
+    // ...
+    ebpf_ext_trace_terminate();
+}
+```
+
+## Adding a new extension keyword
+
+When a consuming extension needs a new keyword for filtering its trace events,
+update these three files in this repository:
+
+### 1. `include/ebpf_ext_tracelog.h`
+
+Add the bitmask constant (use the next available power-of-two starting from
+`0x8`):
+
+```c
+#define EBPF_EXT_TRACELOG_KEYWORD_MY_FEATURE 0x200
+```
+
+Add a corresponding entry in the `ebpf_ext_tracelog_keyword_t` enum:
+
+```c
+typedef enum _ebpf_ext_tracelog_keyword
+{
+    _EBPF_EXT_TRACELOG_KEYWORD_BASE,
+    // ... existing entries ...
+    _EBPF_EXT_TRACELOG_KEYWORD_MY_FEATURE,   // <-- add here
+} ebpf_ext_tracelog_keyword_t;
+```
+
+### 2. `src/ebpf_ext_tracelog.c`
+
+Add shorthand aliases near the top of the file:
+
+```c
+#define KEYWORD_MY_FEATURE EBPF_EXT_TRACELOG_KEYWORD_MY_FEATURE
+#define CASE_MY_FEATURE    case _EBPF_EXT_TRACELOG_KEYWORD_MY_FEATURE
+```
+
+Then add a `CASE_MY_FEATURE` entry to **every** keyword switch macro (e.g.,
+`EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH`, `EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH`,
+etc.). Follow the pattern of existing entries:
+
+```c
+CASE_MY_FEATURE:                                                         \
+    _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_MY_FEATURE, message);     \
+    break;                                                               \
+```
+
+### 3. Build and test
+
+Rebuild and run the existing tests to verify the new keyword compiles
+correctly. If a keyword is used without being added to the switch, the
+`default: ASSERT(!"Invalid keyword")` branch will fire at runtime.
+
+## Reserved keyword bits
+
+| Bit   | Constant                                        | Purpose                  |
+|-------|-------------------------------------------------|--------------------------|
+| `0x1` | `EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT` | Function entry/exit logs |
+| `0x2` | `EBPF_EXT_TRACELOG_KEYWORD_BASE`                | Base/common code logs    |
+| `0x4` | `EBPF_EXT_TRACELOG_KEYWORD_EXTENSION`           | Generic extension logs   |
+| `0x8+`| Extension-specific (XDP, BIND, etc.)            | Per-extension filtering  |
+
+## Available macros
+
+### Entry/exit
+
+- `EBPF_EXT_LOG_ENTRY()` — logs function entry at VERBOSE level.
+- `EBPF_EXT_LOG_EXIT()` — logs function exit at VERBOSE level.
+
+### Message logging
+
+- `EBPF_EXT_LOG_MESSAGE(level, keyword, message)`
+- `EBPF_EXT_LOG_MESSAGE_STRING(level, keyword, message, string_value)`
+- `EBPF_EXT_LOG_MESSAGE_NTSTATUS(level, keyword, message, status)`
+- `EBPF_EXT_LOG_MESSAGE_UINT32(level, keyword, message, value)`
+- `EBPF_EXT_LOG_MESSAGE_UINT64(level, keyword, message, value)`
+- `EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(level, keyword, message, v1, v2)`
+- `EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(level, keyword, message, v1, v2, v3)`
+- `EBPF_EXT_LOG_MESSAGE_BOOL(level, keyword, message, value)`
+- `EBPF_EXT_LOG_MESSAGE_POINTER(level, keyword, message, value)`
+- `EBPF_EXT_LOG_MESSAGE_GUID_STATUS(level, keyword, message, guid, status)`
+
+### Error logging
+
+- `EBPF_EXT_LOG_NTSTATUS_API_FAILURE(keyword, api, status)`
+- `EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(keyword, api, status, message, value)`
+- `EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(keyword, api, status, v1, v2)`
+
+### Convenience / bail macros
+
+- `EBPF_EXT_RETURN_RESULT(status)` — logs and returns an `ebpf_result_t`.
+- `EBPF_EXT_RETURN_NTSTATUS(status)` — logs and returns an `NTSTATUS`.
+- `EBPF_EXT_RETURN_POINTER(type, pointer)` — logs and returns a pointer.
+- `EBPF_EXT_RETURN_BOOL(flag)` — logs and returns a bool.
+- `EBPF_EXT_BAIL_ON_ERROR_RESULT(result)` — goto Exit on failure.
+- `EBPF_EXT_BAIL_ON_ERROR_STATUS(status)` — goto Exit on failure.
+- `EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(keyword, ptr, name, result)`
+- `EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(keyword, ptr, name, status)`
+- `EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(keyword, api, status)`

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -65,7 +65,7 @@ void DriverUnload(...)
 ## Adding a new extension keyword
 
 When a consuming extension needs a new keyword for filtering its trace events,
-update these three files in this repository:
+update these two files in this repository:
 
 ### 1. `include/ebpf_ext_tracelog.h`
 

--- a/include/ebpf_ext_tracelog.h
+++ b/include/ebpf_ext_tracelog.h
@@ -1,0 +1,472 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "framework.h"
+
+#include <TraceLoggingProvider.h>
+#include <winmeta.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    TRACELOGGING_DECLARE_PROVIDER(ebpf_ext_tracelog_provider);
+
+    NTSTATUS
+    ebpf_ext_trace_initiate();
+
+    void
+    ebpf_ext_trace_terminate();
+
+// Event name macros.
+#define EBPF_EXT_TRACELOG_EVENT_SUCCESS "EbpfExtSuccess"
+#define EBPF_EXT_TRACELOG_EVENT_RETURN "EbpfExtReturn"
+#define EBPF_EXT_TRACELOG_EVENT_GENERIC_ERROR "EbpfExtGenericError"
+#define EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE "EbpfExtGenericMessage"
+#define EBPF_EXT_TRACELOG_EVENT_API_ERROR "EbpfExtApiError"
+
+// Keyword bit masks for TraceLoggingProviderEnabled checks.
+#define EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT 0x1
+#define EBPF_EXT_TRACELOG_KEYWORD_BASE 0x2
+#define EBPF_EXT_TRACELOG_KEYWORD_EXTENSION 0x4
+#define EBPF_EXT_TRACELOG_KEYWORD_XDP 0x8
+#define EBPF_EXT_TRACELOG_KEYWORD_BIND 0x10
+#define EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR 0x20
+#define EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS 0x40
+#define EBPF_EXT_TRACELOG_KEYWORD_PROCESS 0x80
+#define EBPF_EXT_TRACELOG_KEYWORD_NETEVENT 0x100
+
+// Trace logging level macros.
+#define EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS WINEVENT_LEVEL_LOG_ALWAYS
+#define EBPF_EXT_TRACELOG_LEVEL_CRITICAL WINEVENT_LEVEL_CRITICAL
+#define EBPF_EXT_TRACELOG_LEVEL_ERROR WINEVENT_LEVEL_ERROR
+#define EBPF_EXT_TRACELOG_LEVEL_WARNING WINEVENT_LEVEL_WARNING
+#define EBPF_EXT_TRACELOG_LEVEL_INFO WINEVENT_LEVEL_INFO
+#define EBPF_EXT_TRACELOG_LEVEL_VERBOSE WINEVENT_LEVEL_VERBOSE
+
+    // Keyword enum for function dispatch.
+    typedef enum _ebpf_ext_tracelog_keyword
+    {
+        _EBPF_EXT_TRACELOG_KEYWORD_BASE,
+        _EBPF_EXT_TRACELOG_KEYWORD_BIND,
+        _EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
+        _EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+        _EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS,
+        _EBPF_EXT_TRACELOG_KEYWORD_XDP,
+        _EBPF_EXT_TRACELOG_KEYWORD_PROCESS,
+        _EBPF_EXT_TRACELOG_KEYWORD_NETEVENT,
+    } ebpf_ext_tracelog_keyword_t;
+
+    // Level enum for function dispatch.
+    typedef enum _ebpf_ext_tracelog_level
+    {
+        _EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS,
+        _EBPF_EXT_TRACELOG_LEVEL_CRITICAL,
+        _EBPF_EXT_TRACELOG_LEVEL_ERROR,
+        _EBPF_EXT_TRACELOG_LEVEL_WARNING,
+        _EBPF_EXT_TRACELOG_LEVEL_INFO,
+        _EBPF_EXT_TRACELOG_LEVEL_VERBOSE
+    } ebpf_ext_tracelog_level_t;
+
+//
+// Function entry/exit macros.
+//
+
+#define EBPF_EXT_LOG_ENTRY()                                                    \
+    if (TraceLoggingProviderEnabled(                                            \
+            ebpf_ext_tracelog_provider,                                         \
+            EBPF_EXT_TRACELOG_LEVEL_VERBOSE,                                    \
+            EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT)) {                   \
+        TraceLoggingWrite(                                                      \
+            ebpf_ext_tracelog_provider,                                         \
+            EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                            \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                          \
+            TraceLoggingKeyword(EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT), \
+            TraceLoggingOpcode(WINEVENT_OPCODE_START),                          \
+            TraceLoggingString(__FUNCTION__, "Enter"));                         \
+    }
+
+#define EBPF_EXT_LOG_EXIT()                                                     \
+    if (TraceLoggingProviderEnabled(                                            \
+            ebpf_ext_tracelog_provider,                                         \
+            EBPF_EXT_TRACELOG_LEVEL_VERBOSE,                                    \
+            EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT)) {                   \
+        TraceLoggingWrite(                                                      \
+            ebpf_ext_tracelog_provider,                                         \
+            EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                            \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                          \
+            TraceLoggingKeyword(EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT), \
+            TraceLoggingOpcode(WINEVENT_OPCODE_STOP),                           \
+            TraceLoggingString(__FUNCTION__, "Exit"));                          \
+    }
+
+//
+// Low-level trace macros (direct TraceLoggingWrite wrappers) and corresponding function declarations.
+//
+
+#define _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(keyword, api, status) \
+    TraceLoggingWrite(                                           \
+        ebpf_ext_tracelog_provider,                              \
+        EBPF_EXT_TRACELOG_EVENT_API_ERROR,                       \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                 \
+        TraceLoggingKeyword((keyword)),                          \
+        TraceLoggingString(api, "api"),                          \
+        TraceLoggingNTStatus(status));
+    void
+    ebpf_ext_log_ntstatus_api_failure(
+        ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status);
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE(keyword, api, status)                \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, 0, keyword)) { \
+        ebpf_ext_log_ntstatus_api_failure(_##keyword##, api, status);          \
+    }
+
+#define _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(keyword, api, status, message, value) \
+    TraceLoggingWrite(                                                                          \
+        ebpf_ext_tracelog_provider,                                                             \
+        EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                      \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                \
+        TraceLoggingKeyword((keyword)),                                                         \
+        TraceLoggingString(api, "api"),                                                         \
+        TraceLoggingNTStatus(status),                                                           \
+        TraceLoggingString(message, "Message"),                                                 \
+        TraceLoggingString((value), (#value)));
+    void
+    ebpf_ext_log_ntstatus_api_failure_message_string(
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* api_name,
+        NTSTATUS status,
+        _In_z_ const char* message,
+        _In_z_ const char* string_value);
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(keyword, api, status, message, string_value)       \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, 0, keyword)) {                              \
+        ebpf_ext_log_ntstatus_api_failure_message_string(_##keyword##, api, status, message, string_value); \
+    }
+
+#define _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(keyword, api, status, value1, value2) \
+    TraceLoggingWrite(                                                                         \
+        ebpf_ext_tracelog_provider,                                                            \
+        EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                     \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                               \
+        TraceLoggingKeyword(keyword),                                                          \
+        TraceLoggingString(api, "api"),                                                        \
+        TraceLoggingNTStatus(status),                                                          \
+        TraceLoggingUInt64((value1), (#value1)),                                               \
+        TraceLoggingUInt64((value2), (#value2)));
+    void
+    ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* api,
+        NTSTATUS status,
+        uint64_t value1,
+        uint64_t value2);
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(keyword, api, status, value1, value2)       \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, 0, keyword)) {                      \
+        ebpf_ext_log_ntstatus_api_failure_uint64_uint64(_##keyword##, api, status, value1, value2); \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE(trace_level, keyword, message) \
+    TraceLoggingWrite(                                       \
+        ebpf_ext_tracelog_provider,                          \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,             \
+        TraceLoggingLevel(trace_level),                      \
+        TraceLoggingKeyword((keyword)),                      \
+        TraceLoggingString(message, "Message"));
+    void
+    ebpf_ext_log_message(
+        ebpf_ext_tracelog_level_t trace_level, ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* message);
+#define EBPF_EXT_LOG_MESSAGE(trace_level, keyword, message)                              \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message(_##trace_level##, _##keyword##, message);                   \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                     \
+        ebpf_ext_tracelog_provider,                                        \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                           \
+        TraceLoggingLevel(trace_level),                                    \
+        TraceLoggingKeyword((keyword)),                                    \
+        TraceLoggingString(message, "Message"),                            \
+        TraceLoggingString((value), (#value)));
+    void
+    ebpf_ext_log_message_string(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        _In_z_ const char* string_value);
+#define EBPF_EXT_LOG_MESSAGE_STRING(trace_level, keyword, message, value)                \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_string(_##trace_level##, _##keyword##, message, value);     \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, keyword, message, status) \
+    TraceLoggingWrite(                                                        \
+        ebpf_ext_tracelog_provider,                                           \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                              \
+        TraceLoggingLevel(trace_level),                                       \
+        TraceLoggingKeyword((keyword)),                                       \
+        TraceLoggingString(message, "Message"),                               \
+        TraceLoggingNTStatus(status));
+    void
+    ebpf_ext_log_message_ntstatus(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        NTSTATUS status);
+#define EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, keyword, message, status)             \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_ntstatus(_##trace_level##, _##keyword##, message, status);  \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                   \
+        ebpf_ext_tracelog_provider,                                      \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                         \
+        TraceLoggingLevel(trace_level),                                  \
+        TraceLoggingKeyword((keyword)),                                  \
+        TraceLoggingString(message, "Message"),                          \
+        TraceLoggingBool((value), (#value)));
+    void
+    ebpf_ext_log_message_bool(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        bool value);
+#define EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, keyword, message, value)                  \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_bool(_##trace_level##, _##keyword##, message, value);       \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                      \
+        ebpf_ext_tracelog_provider,                                         \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                            \
+        TraceLoggingLevel(trace_level),                                     \
+        TraceLoggingKeyword((keyword)),                                     \
+        TraceLoggingString(message, "Message"),                             \
+        TraceLoggingPointer((value), (#value)));
+    void
+    ebpf_ext_log_message_pointer(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        _In_opt_ const void* value);
+#define EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, keyword, message, value)               \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_pointer(_##trace_level##, _##keyword##, message, value);    \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                     \
+        ebpf_ext_tracelog_provider,                                        \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                           \
+        TraceLoggingLevel(trace_level),                                    \
+        TraceLoggingKeyword((keyword)),                                    \
+        TraceLoggingString(message, "Message"),                            \
+        TraceLoggingUInt32((value), (#value)));
+    void
+    ebpf_ext_log_message_uint32(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        uint32_t value);
+#define EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, keyword, message, value)                \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_uint32(_##trace_level##, _##keyword##, message, value);     \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                     \
+        ebpf_ext_tracelog_provider,                                        \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                           \
+        TraceLoggingLevel(trace_level),                                    \
+        TraceLoggingKeyword((keyword)),                                    \
+        TraceLoggingString(message, "Message"),                            \
+        TraceLoggingUInt64((value), (#value)));
+    void
+    ebpf_ext_log_message_uint64(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        uint64_t value);
+#define EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, keyword, message, value)                \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) { \
+        ebpf_ext_log_message_uint64(_##trace_level##, _##keyword##, message, value);     \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, keyword, message, value1, value2) \
+    TraceLoggingWrite(                                                                     \
+        ebpf_ext_tracelog_provider,                                                        \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                                           \
+        TraceLoggingLevel(trace_level),                                                    \
+        TraceLoggingKeyword((keyword)),                                                    \
+        TraceLoggingString(message, "Message"),                                            \
+        TraceLoggingUInt64((value1), (#value1)),                                           \
+        TraceLoggingUInt64((value2), (#value2)));
+    void
+    ebpf_ext_log_message_uint64_uint64(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        uint64_t value1,
+        uint64_t value2);
+#define EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, keyword, message, value1, value2)            \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) {             \
+        ebpf_ext_log_message_uint64_uint64(_##trace_level##, _##keyword##, message, value1, value2); \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, keyword, message, value1, value2, value3) \
+    TraceLoggingWrite(                                                                                    \
+        ebpf_ext_tracelog_provider,                                                                       \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                                                          \
+        TraceLoggingLevel(trace_level),                                                                   \
+        TraceLoggingKeyword((keyword)),                                                                   \
+        TraceLoggingString(message, "Message"),                                                           \
+        TraceLoggingUInt64((value1), (#value1)),                                                          \
+        TraceLoggingUInt64((value2), (#value2)),                                                          \
+        TraceLoggingUInt64((value3), (#value3)));
+    void
+    ebpf_ext_log_message_uint64_uint64_uint64(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        uint64_t value1,
+        uint64_t value2,
+        uint64_t value3);
+#define EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, keyword, message, value1, value2, value3)            \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) {                            \
+        ebpf_ext_log_message_uint64_uint64_uint64(_##trace_level##, _##keyword##, message, value1, value2, value3); \
+    }
+
+#define _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, keyword, message, guid, status) \
+    TraceLoggingWrite(                                                                 \
+        ebpf_ext_tracelog_provider,                                                    \
+        EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                                       \
+        TraceLoggingLevel((trace_level)),                                              \
+        TraceLoggingKeyword((keyword)),                                                \
+        TraceLoggingString((message), "Message"),                                      \
+        TraceLoggingGuid((guid), (#guid)),                                             \
+        TraceLoggingNTStatus((status), "Status"));
+    void
+    ebpf_ext_log_message_guid_status(
+        ebpf_ext_tracelog_level_t trace_level,
+        ebpf_ext_tracelog_keyword_t keyword,
+        _In_z_ const char* message,
+        _In_ const GUID* guid,
+        NTSTATUS status);
+#define EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, keyword, message, guid, status)            \
+    if (TraceLoggingProviderEnabled(ebpf_ext_tracelog_provider, trace_level, keyword)) {         \
+        ebpf_ext_log_message_guid_status(_##trace_level##, _##keyword##, message, guid, status); \
+    }
+
+//
+// Convenience macros built on top of the above primary trace macros.
+//
+
+#define EBPF_EXT_LOG_FUNCTION_SUCCESS() \
+    EBPF_EXT_LOG_MESSAGE(               \
+        EBPF_EXT_TRACELOG_LEVEL_VERBOSE, EBPF_EXT_TRACELOG_KEYWORD_BASE, __FUNCTION__ " returned success")
+
+#define EBPF_EXT_LOG_FUNCTION_ERROR(result) \
+    EBPF_EXT_LOG_MESSAGE_UINT64(            \
+        EBPF_EXT_TRACELOG_LEVEL_ERROR,      \
+        EBPF_EXT_TRACELOG_KEYWORD_BASE,     \
+        __FUNCTION__ " returned error",     \
+        result)
+
+#define EBPF_EXT_RETURN_RESULT(status)                 \
+    do {                                               \
+        ebpf_result_t local_result = (status);         \
+        if (local_result == EBPF_SUCCESS) {            \
+            EBPF_EXT_LOG_FUNCTION_SUCCESS();           \
+        } else {                                       \
+            EBPF_EXT_LOG_FUNCTION_ERROR(local_result); \
+        }                                              \
+        return local_result;                           \
+    } while (false);
+
+#define EBPF_EXT_RETURN_NTSTATUS(status)               \
+    do {                                               \
+        NTSTATUS local_result = (status);              \
+        if (NT_SUCCESS(local_result)) {                \
+            EBPF_EXT_LOG_FUNCTION_SUCCESS();           \
+        } else {                                       \
+            EBPF_EXT_LOG_FUNCTION_ERROR(local_result); \
+        }                                              \
+        return local_result;                           \
+    } while (false);
+
+#define EBPF_EXT_RETURN_POINTER(type, pointer) \
+    do {                                       \
+        type local_result = (type)(pointer);   \
+        EBPF_EXT_LOG_MESSAGE_POINTER(          \
+            EBPF_EXT_TRACELOG_LEVEL_VERBOSE,   \
+            EBPF_EXT_TRACELOG_KEYWORD_BASE,    \
+            __FUNCTION__ " returned",          \
+            local_result);                     \
+        return local_result;                   \
+    } while (false);
+
+#define EBPF_EXT_RETURN_BOOL(flag)           \
+    do {                                     \
+        bool local_result = (flag);          \
+        EBPF_EXT_LOG_MESSAGE_BOOL(           \
+            EBPF_EXT_TRACELOG_LEVEL_VERBOSE, \
+            EBPF_EXT_TRACELOG_KEYWORD_BASE,  \
+            __FUNCTION__ " returned",        \
+            !!local_result);                 \
+        return local_result;                 \
+    } while (false);
+
+#define EBPF_EXT_BAIL_ON_ERROR_RESULT(result)          \
+    do {                                               \
+        ebpf_result_t local_result = (result);         \
+        if (local_result != EBPF_SUCCESS) {            \
+            EBPF_EXT_LOG_FUNCTION_ERROR(local_result); \
+            goto Exit;                                 \
+        }                                              \
+    } while (false);
+
+#define EBPF_EXT_BAIL_ON_ERROR_STATUS(status)          \
+    do {                                               \
+        NTSTATUS local_status = (status);              \
+        if (!NT_SUCCESS(local_status)) {               \
+            EBPF_EXT_LOG_FUNCTION_ERROR(local_status); \
+            goto Exit;                                 \
+        }                                              \
+    } while (false);
+
+#define EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(keyword, ptr, ptr_name, result)                                     \
+    do {                                                                                                          \
+        if ((ptr) == NULL) {                                                                                      \
+            EBPF_EXT_LOG_MESSAGE(                                                                                 \
+                EBPF_EXT_TRACELOG_LEVEL_ERROR, ##keyword##, "Failed to allocate " #ptr_name " in " __FUNCTION__); \
+            (result) = EBPF_NO_MEMORY;                                                                            \
+            goto Exit;                                                                                            \
+        }                                                                                                         \
+    } while (false);
+
+#define EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(keyword, ptr, ptr_name, status)                                     \
+    do {                                                                                                          \
+        if ((ptr) == NULL) {                                                                                      \
+            EBPF_EXT_LOG_MESSAGE(                                                                                 \
+                EBPF_EXT_TRACELOG_LEVEL_ERROR, ##keyword##, "Failed to allocate " #ptr_name " in " __FUNCTION__); \
+            (status) = STATUS_INSUFFICIENT_RESOURCES;                                                             \
+            goto Exit;                                                                                            \
+        }                                                                                                         \
+    } while (false);
+
+#define EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(keyword, api, status)            \
+    do {                                                                     \
+        NTSTATUS local_status = (status);                                    \
+        if (!NT_SUCCESS(local_status)) {                                     \
+            EBPF_EXT_LOG_NTSTATUS_API_FAILURE(##keyword##, (api), (status)); \
+            goto Exit;                                                       \
+        }                                                                    \
+    } while (false);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/ebpf_ext_tracelog.h
+++ b/include/ebpf_ext_tracelog.h
@@ -8,19 +8,6 @@
 #include <TraceLoggingProvider.h>
 #include <winmeta.h>
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-    TRACELOGGING_DECLARE_PROVIDER(ebpf_ext_tracelog_provider);
-
-    NTSTATUS
-    ebpf_ext_trace_initiate();
-
-    void
-    ebpf_ext_trace_terminate();
-
 // Event name macros.
 #define EBPF_EXT_TRACELOG_EVENT_SUCCESS "EbpfExtSuccess"
 #define EBPF_EXT_TRACELOG_EVENT_RETURN "EbpfExtReturn"
@@ -29,6 +16,11 @@ extern "C"
 #define EBPF_EXT_TRACELOG_EVENT_API_ERROR "EbpfExtApiError"
 
 // Keyword bit masks for TraceLoggingProviderEnabled checks.
+// Common keywords (bits 0x1-0x4) are reserved by this library.
+// Extension-specific keywords use bits 0x8 and above.
+// To add a new extension keyword, add a #define here, a corresponding enum entry
+// in ebpf_ext_tracelog_keyword_t, and switch cases in ebpf_ext_tracelog.c.
+// See docs/tracing.md for details.
 #define EBPF_EXT_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT 0x1
 #define EBPF_EXT_TRACELOG_KEYWORD_BASE 0x2
 #define EBPF_EXT_TRACELOG_KEYWORD_EXTENSION 0x4
@@ -46,6 +38,19 @@ extern "C"
 #define EBPF_EXT_TRACELOG_LEVEL_WARNING WINEVENT_LEVEL_WARNING
 #define EBPF_EXT_TRACELOG_LEVEL_INFO WINEVENT_LEVEL_INFO
 #define EBPF_EXT_TRACELOG_LEVEL_VERBOSE WINEVENT_LEVEL_VERBOSE
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    TRACELOGGING_DECLARE_PROVIDER(ebpf_ext_tracelog_provider);
+
+    NTSTATUS
+    ebpf_ext_trace_initiate();
+
+    void
+    ebpf_ext_trace_terminate();
 
     // Keyword enum for function dispatch.
     typedef enum _ebpf_ext_tracelog_keyword

--- a/src/ebpf_ext_rundown.c
+++ b/src/ebpf_ext_rundown.c
@@ -2,24 +2,33 @@
 // SPDX-License-Identifier: MIT
 
 #include "ebpf_ext_rundown.h"
+#include "ebpf_ext_tracelog.h"
 
 void
 ebpf_ext_init_rundown(_Inout_ ebpf_ext_hook_rundown_t* rundown)
 {
+    EBPF_EXT_LOG_ENTRY();
+
     ASSERT(rundown->rundown_initialized == false);
 
     ExInitializeRundownProtection(&rundown->protection);
     rundown->rundown_occurred = false;
     rundown->rundown_initialized = true;
+
+    EBPF_EXT_LOG_EXIT();
 }
 
 void
 ebpf_ext_wait_for_rundown(_Inout_ ebpf_ext_hook_rundown_t* rundown)
 {
+    EBPF_EXT_LOG_ENTRY();
+
     ASSERT(rundown->rundown_initialized == true);
 
     ExWaitForRundownProtectionRelease(&rundown->protection);
     rundown->rundown_occurred = true;
+
+    EBPF_EXT_LOG_EXIT();
 }
 
 _Must_inspect_result_ bool

--- a/src/ebpf_ext_tracelog.c
+++ b/src/ebpf_ext_tracelog.c
@@ -8,6 +8,8 @@
 //       ebpf_ext_tracelog_provider,
 //       "MyExtProvider",
 //       (0x..., 0x..., 0x..., 0x.., 0x.., 0x.., 0x.., 0x.., 0x.., 0x.., 0x..));
+//
+// See docs/tracing.md for full setup guidance and how to add new keywords.
 
 #include "ebpf_ext_tracelog.h"
 

--- a/src/ebpf_ext_tracelog.c
+++ b/src/ebpf_ext_tracelog.c
@@ -1,0 +1,828 @@
+// Copyright (c) eBPF for Windows contributors
+// SPDX-License-Identifier: MIT
+
+// The consuming repo must provide a TRACELOGGING_DEFINE_PROVIDER definition for
+// ebpf_ext_tracelog_provider with its own provider name and GUID. For example:
+//
+//   TRACELOGGING_DEFINE_PROVIDER(
+//       ebpf_ext_tracelog_provider,
+//       "MyExtProvider",
+//       (0x..., 0x..., 0x..., 0x.., 0x.., 0x.., 0x.., 0x.., 0x.., 0x.., 0x..));
+
+#include "ebpf_ext_tracelog.h"
+
+static bool _ebpf_ext_trace_initiated = false;
+
+NTSTATUS
+ebpf_ext_trace_initiate()
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    if (_ebpf_ext_trace_initiated) {
+        goto Exit;
+    }
+
+    status = TraceLoggingRegister(ebpf_ext_tracelog_provider);
+    if (status != STATUS_SUCCESS) {
+        goto Exit;
+    } else {
+        _ebpf_ext_trace_initiated = true;
+    }
+Exit:
+    return status;
+}
+
+// Prevent tail call optimization of the call to TraceLoggingUnregister to resolve verifier stop C4/DD
+// "An attempt was made to unload a driver without calling EtwUnregister".
+#pragma optimize("", off)
+void
+ebpf_ext_trace_terminate()
+{
+    if (_ebpf_ext_trace_initiated) {
+        TraceLoggingUnregister(ebpf_ext_tracelog_provider);
+        _ebpf_ext_trace_initiated = false;
+    }
+}
+#pragma optimize("", on)
+
+// Shorthand keyword aliases for use in switch macros.
+#define KEYWORD_BASE EBPF_EXT_TRACELOG_KEYWORD_BASE
+#define KEYWORD_BIND EBPF_EXT_TRACELOG_KEYWORD_BIND
+#define KEYWORD_EXT EBPF_EXT_TRACELOG_KEYWORD_EXTENSION
+#define KEYWORD_PROCESS EBPF_EXT_TRACELOG_KEYWORD_PROCESS
+#define KEYWORD_NETEVENT EBPF_EXT_TRACELOG_KEYWORD_NETEVENT
+#define KEYWORD_SOCK_ADDR EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR
+#define KEYWORD_SOCK_OPS EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS
+#define KEYWORD_XDP EBPF_EXT_TRACELOG_KEYWORD_XDP
+
+#define CASE_BASE case _EBPF_EXT_TRACELOG_KEYWORD_BASE
+#define CASE_BIND case _EBPF_EXT_TRACELOG_KEYWORD_BIND
+#define CASE_EXT case _EBPF_EXT_TRACELOG_KEYWORD_EXTENSION
+#define CASE_PROCESS case _EBPF_EXT_TRACELOG_KEYWORD_PROCESS
+#define CASE_NETEVENT case _EBPF_EXT_TRACELOG_KEYWORD_NETEVENT
+#define CASE_SOCK_ADDR case _EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR
+#define CASE_SOCK_OPS case _EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS
+#define CASE_XDP case _EBPF_EXT_TRACELOG_KEYWORD_XDP
+
+// Shorthand level aliases.
+#define LEVEL_LOG_ALWAYS EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS
+#define LEVEL_CRITICAL EBPF_EXT_TRACELOG_LEVEL_CRITICAL
+#define LEVEL_ERROR EBPF_EXT_TRACELOG_LEVEL_ERROR
+#define LEVEL_WARNING EBPF_EXT_TRACELOG_LEVEL_WARNING
+#define LEVEL_INFO EBPF_EXT_TRACELOG_LEVEL_INFO
+#define LEVEL_VERBOSE EBPF_EXT_TRACELOG_LEVEL_VERBOSE
+
+#define CASE_LOG_ALWAYS case _EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS
+#define CASE_CRITICAL case _EBPF_EXT_TRACELOG_LEVEL_CRITICAL
+#define CASE_LEVEL_ERROR case _EBPF_EXT_TRACELOG_LEVEL_ERROR
+#define CASE_WARNING case _EBPF_EXT_TRACELOG_LEVEL_WARNING
+#define CASE_INFO case _EBPF_EXT_TRACELOG_LEVEL_INFO
+#define CASE_VERBOSE case _EBPF_EXT_TRACELOG_LEVEL_VERBOSE
+
+//
+// Keyword switch macros for each log variant.
+//
+
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status)       \
+    switch (keyword) {                                                           \
+    CASE_BASE:                                                                   \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_BASE, api_name, status);      \
+        break;                                                                   \
+    CASE_EXT:                                                                    \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_EXT, api_name, status);       \
+        break;                                                                   \
+    CASE_BIND:                                                                   \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_BIND, api_name, status);      \
+        break;                                                                   \
+    CASE_NETEVENT:                                                               \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_NETEVENT, api_name, status);  \
+        break;                                                                   \
+    CASE_PROCESS:                                                                \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_PROCESS, api_name, status);   \
+        break;                                                                   \
+    CASE_SOCK_ADDR:                                                              \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_SOCK_ADDR, api_name, status); \
+        break;                                                                   \
+    CASE_SOCK_OPS:                                                               \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_SOCK_OPS, api_name, status);  \
+        break;                                                                   \
+    CASE_XDP:                                                                    \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_XDP, api_name, status);       \
+        break;                                                                   \
+    default:                                                                     \
+        ASSERT(!"Invalid keyword");                                              \
+        break;                                                                   \
+    }
+
+#pragma warning(push)
+#pragma warning(disable : 6262) // Function uses 'N' bytes of stack.  Consider moving some data to heap.
+
+__declspec(noinline) void ebpf_ext_log_ntstatus_api_failure(
+    ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status)
+{
+    EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status);
+}
+
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING_KEYWORD_SWITCH(api_name, status, message, string_value)       \
+    switch (keyword) {                                                                                                 \
+    CASE_BASE:                                                                                                         \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_BASE, api_name, status, message, string_value);      \
+        break;                                                                                                         \
+    CASE_EXT:                                                                                                          \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_EXT, api_name, status, message, string_value);       \
+        break;                                                                                                         \
+    CASE_BIND:                                                                                                         \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_BIND, api_name, status, message, string_value);      \
+        break;                                                                                                         \
+    CASE_NETEVENT:                                                                                                     \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_NETEVENT, api_name, status, message, string_value);  \
+        break;                                                                                                         \
+    CASE_PROCESS:                                                                                                      \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_PROCESS, api_name, status, message, string_value);   \
+        break;                                                                                                         \
+    CASE_SOCK_ADDR:                                                                                                    \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_SOCK_ADDR, api_name, status, message, string_value); \
+        break;                                                                                                         \
+    CASE_SOCK_OPS:                                                                                                     \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_SOCK_OPS, api_name, status, message, string_value);  \
+        break;                                                                                                         \
+    CASE_XDP:                                                                                                          \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_XDP, api_name, status, message, string_value);       \
+        break;                                                                                                         \
+    default:                                                                                                           \
+        ASSERT(!"Invalid keyword");                                                                                    \
+        break;                                                                                                         \
+    }
+
+__declspec(noinline) void ebpf_ext_log_ntstatus_api_failure_message_string(
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* api_name,
+    NTSTATUS status,
+    _In_z_ const char* message,
+    _In_z_ const char* string_value)
+{
+    EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING_KEYWORD_SWITCH(api_name, status, message, string_value);
+}
+
+#define EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64_KEYWORD_SWITCH(api_name, status, value1, value2)       \
+    switch (keyword) {                                                                                         \
+    CASE_BASE:                                                                                                 \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_BASE, api_name, status, value1, value2);      \
+        break;                                                                                                 \
+    CASE_EXT:                                                                                                  \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_EXT, api_name, status, value1, value2);       \
+        break;                                                                                                 \
+    CASE_BIND:                                                                                                 \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_BIND, api_name, status, value1, value2);      \
+        break;                                                                                                 \
+    CASE_NETEVENT:                                                                                             \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_NETEVENT, api_name, status, value1, value2);  \
+        break;                                                                                                 \
+    CASE_PROCESS:                                                                                              \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_PROCESS, api_name, status, value1, value2);   \
+        break;                                                                                                 \
+    CASE_SOCK_ADDR:                                                                                            \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_SOCK_ADDR, api_name, status, value1, value2); \
+        break;                                                                                                 \
+    CASE_SOCK_OPS:                                                                                             \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_SOCK_OPS, api_name, status, value1, value2);  \
+        break;                                                                                                 \
+    CASE_XDP:                                                                                                  \
+        _EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_XDP, api_name, status, value1, value2);       \
+        break;                                                                                                 \
+    default:                                                                                                   \
+        ASSERT(!"Invalid keyword");                                                                            \
+        break;                                                                                                 \
+    }
+
+__declspec(noinline) void ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
+    ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status, uint64_t value1, uint64_t value2)
+{
+    EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64_KEYWORD_SWITCH(api_name, status, value1, value2);
+}
+
+//
+// Message logging functions (dispatch on trace_level then keyword).
+//
+
+#define EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(trace_level, message)       \
+    switch (keyword) {                                                  \
+    CASE_BASE:                                                          \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_BASE, message);      \
+        break;                                                          \
+    CASE_BIND:                                                          \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_BIND, message);      \
+        break;                                                          \
+    CASE_EXT:                                                           \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_EXT, message);       \
+        break;                                                          \
+    CASE_NETEVENT:                                                      \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_NETEVENT, message);  \
+        break;                                                          \
+    CASE_PROCESS:                                                       \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_PROCESS, message);   \
+        break;                                                          \
+    CASE_SOCK_ADDR:                                                     \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_SOCK_ADDR, message); \
+        break;                                                          \
+    CASE_SOCK_OPS:                                                      \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_SOCK_OPS, message);  \
+        break;                                                          \
+    CASE_XDP:                                                           \
+        _EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_XDP, message);       \
+        break;                                                          \
+    default:                                                            \
+        ASSERT(!"Invalid keyword");                                     \
+        break;                                                          \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message(
+    ebpf_ext_tracelog_level_t trace_level, ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* message)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_CRITICAL, message);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_ERROR, message);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_WARNING, message);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_INFO, message);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_VERBOSE, message);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(trace_level, message, string_value)       \
+    switch (keyword) {                                                                       \
+    CASE_BASE:                                                                               \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_BASE, message, string_value);      \
+        break;                                                                               \
+    CASE_BIND:                                                                               \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_BIND, message, string_value);      \
+        break;                                                                               \
+    CASE_EXT:                                                                                \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_EXT, message, string_value);       \
+        break;                                                                               \
+    CASE_NETEVENT:                                                                           \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_NETEVENT, message, string_value);  \
+        break;                                                                               \
+    CASE_PROCESS:                                                                            \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_PROCESS, message, string_value);   \
+        break;                                                                               \
+    CASE_SOCK_ADDR:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_SOCK_ADDR, message, string_value); \
+        break;                                                                               \
+    CASE_SOCK_OPS:                                                                           \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_SOCK_OPS, message, string_value);  \
+        break;                                                                               \
+    CASE_XDP:                                                                                \
+        _EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_XDP, message, string_value);       \
+        break;                                                                               \
+    default:                                                                                 \
+        ASSERT(!"Invalid keyword");                                                          \
+        break;                                                                               \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_string(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    _In_z_ const char* string_value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, string_value);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_CRITICAL, message, string_value);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_ERROR, message, string_value);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_WARNING, message, string_value);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_INFO, message, string_value);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_VERBOSE, message, string_value);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                   \
+    CASE_BASE:                                                                           \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                           \
+    CASE_BIND:                                                                           \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                           \
+    CASE_EXT:                                                                            \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                           \
+    CASE_NETEVENT:                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_NETEVENT, message, status);  \
+        break;                                                                           \
+    CASE_PROCESS:                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_PROCESS, message, status);   \
+        break;                                                                           \
+    CASE_SOCK_ADDR:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                           \
+    CASE_SOCK_OPS:                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                           \
+    CASE_XDP:                                                                            \
+        _EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                           \
+    default:                                                                             \
+        ASSERT(!"Invalid keyword");                                                      \
+        break;                                                                           \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_ntstatus(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    NTSTATUS status)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, status);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_CRITICAL, message, status);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_ERROR, message, status);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_WARNING, message, status);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_INFO, message, status);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_VERBOSE, message, status);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(trace_level, message, value)       \
+    switch (keyword) {                                                              \
+    CASE_BASE:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_BASE, message, value);      \
+        break;                                                                      \
+    CASE_BIND:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_BIND, message, value);      \
+        break;                                                                      \
+    CASE_EXT:                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_EXT, message, value);       \
+        break;                                                                      \
+    CASE_NETEVENT:                                                                  \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_NETEVENT, message, value);  \
+        break;                                                                      \
+    CASE_PROCESS:                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_PROCESS, message, value);   \
+        break;                                                                      \
+    CASE_SOCK_ADDR:                                                                 \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_SOCK_ADDR, message, value); \
+        break;                                                                      \
+    CASE_SOCK_OPS:                                                                  \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_SOCK_OPS, message, value);  \
+        break;                                                                      \
+    CASE_XDP:                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_BOOL(trace_level, KEYWORD_XDP, message, value);       \
+        break;                                                                      \
+    default:                                                                        \
+        ASSERT(!"Invalid keyword");                                                 \
+        break;                                                                      \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_bool(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    bool value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_BOOL_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(trace_level, message, value)       \
+    switch (keyword) {                                                                 \
+    CASE_BASE:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_BASE, message, value);      \
+        break;                                                                         \
+    CASE_BIND:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_BIND, message, value);      \
+        break;                                                                         \
+    CASE_EXT:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_EXT, message, value);       \
+        break;                                                                         \
+    CASE_NETEVENT:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_NETEVENT, message, value);  \
+        break;                                                                         \
+    CASE_PROCESS:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_PROCESS, message, value);   \
+        break;                                                                         \
+    CASE_SOCK_ADDR:                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_SOCK_ADDR, message, value); \
+        break;                                                                         \
+    CASE_SOCK_OPS:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_SOCK_OPS, message, value);  \
+        break;                                                                         \
+    CASE_XDP:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_POINTER(trace_level, KEYWORD_XDP, message, value);       \
+        break;                                                                         \
+    default:                                                                           \
+        ASSERT(!"Invalid keyword");                                                    \
+        break;                                                                         \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_pointer(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    _In_opt_ const void* value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_POINTER_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                 \
+    CASE_BASE:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                         \
+    CASE_BIND:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                         \
+    CASE_EXT:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                         \
+    CASE_NETEVENT:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_NETEVENT, message, status);  \
+        break;                                                                         \
+    CASE_PROCESS:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_PROCESS, message, status);   \
+        break;                                                                         \
+    CASE_SOCK_ADDR:                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                         \
+    CASE_SOCK_OPS:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                         \
+    CASE_XDP:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                         \
+    default:                                                                           \
+        ASSERT(!"Invalid keyword");                                                    \
+        break;                                                                         \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_uint32(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint32_t value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                 \
+    CASE_BASE:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                         \
+    CASE_BIND:                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                         \
+    CASE_EXT:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                         \
+    CASE_NETEVENT:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_NETEVENT, message, status);  \
+        break;                                                                         \
+    CASE_PROCESS:                                                                      \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_PROCESS, message, status);   \
+        break;                                                                         \
+    CASE_SOCK_ADDR:                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                         \
+    CASE_SOCK_OPS:                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                         \
+    CASE_XDP:                                                                          \
+        _EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                         \
+    default:                                                                           \
+        ASSERT(!"Invalid keyword");                                                    \
+        break;                                                                         \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_uint64(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(trace_level, message, value1, value2)       \
+    switch (keyword) {                                                                                \
+    CASE_BASE:                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_BASE, message, value1, value2);      \
+        break;                                                                                        \
+    CASE_EXT:                                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_EXT, message, value1, value2);       \
+        break;                                                                                        \
+    CASE_BIND:                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_BIND, message, value1, value2);      \
+        break;                                                                                        \
+    CASE_NETEVENT:                                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_NETEVENT, message, value1, value2);  \
+        break;                                                                                        \
+    CASE_PROCESS:                                                                                     \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_PROCESS, message, value1, value2);   \
+        break;                                                                                        \
+    CASE_SOCK_ADDR:                                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_SOCK_ADDR, message, value1, value2); \
+        break;                                                                                        \
+    CASE_SOCK_OPS:                                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_SOCK_OPS, message, value1, value2);  \
+        break;                                                                                        \
+    CASE_XDP:                                                                                         \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_XDP, message, value1, value2);       \
+        break;                                                                                        \
+    default:                                                                                          \
+        ASSERT(!"Invalid keyword");                                                                   \
+        break;                                                                                        \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_uint64_uint64(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value1,
+    uint64_t value2)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value1, value2);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value1, value2);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value1, value2);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value1, value2);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value1, value2);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value1, value2);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(trace_level, message, value1, value2, value3)       \
+    switch (keyword) {                                                                                               \
+    CASE_BASE:                                                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_BASE, message, value1, value2, value3);      \
+        break;                                                                                                       \
+    CASE_EXT:                                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_EXT, message, value1, value2, value3);       \
+        break;                                                                                                       \
+    CASE_BIND:                                                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_BIND, message, value1, value2, value3);      \
+        break;                                                                                                       \
+    CASE_NETEVENT:                                                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_NETEVENT, message, value1, value2, value3);  \
+        break;                                                                                                       \
+    CASE_PROCESS:                                                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_PROCESS, message, value1, value2, value3);   \
+        break;                                                                                                       \
+    CASE_SOCK_ADDR:                                                                                                  \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_SOCK_ADDR, message, value1, value2, value3); \
+        break;                                                                                                       \
+    CASE_SOCK_OPS:                                                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_SOCK_OPS, message, value1, value2, value3);  \
+        break;                                                                                                       \
+    CASE_XDP:                                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_XDP, message, value1, value2, value3);       \
+        break;                                                                                                       \
+    default:                                                                                                         \
+        ASSERT(!"Invalid keyword");                                                                                  \
+        break;                                                                                                       \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_uint64_uint64_uint64(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value1,
+    uint64_t value2,
+    uint64_t value3)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value1, value2, value3);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value1, value2, value3);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value1, value2, value3);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value1, value2, value3);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value1, value2, value3);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value1, value2, value3);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#define EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(trace_level, keyword, message, guid, status) \
+    switch (keyword) {                                                                               \
+    CASE_BASE:                                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_BASE, message, guid, status);         \
+        break;                                                                                       \
+    CASE_BIND:                                                                                       \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_BIND, message, guid, status);         \
+        break;                                                                                       \
+    CASE_EXT:                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_EXT, message, guid, status);          \
+        break;                                                                                       \
+    CASE_NETEVENT:                                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_NETEVENT, message, guid, status);     \
+        break;                                                                                       \
+    CASE_PROCESS:                                                                                    \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_PROCESS, message, guid, status);      \
+        break;                                                                                       \
+    CASE_SOCK_ADDR:                                                                                  \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_SOCK_ADDR, message, guid, status);    \
+        break;                                                                                       \
+    CASE_SOCK_OPS:                                                                                   \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_SOCK_OPS, message, guid, status);     \
+        break;                                                                                       \
+    CASE_XDP:                                                                                        \
+        _EBPF_EXT_LOG_MESSAGE_GUID_STATUS(trace_level, KEYWORD_XDP, message, guid, status);          \
+        break;                                                                                       \
+    default:                                                                                         \
+        ASSERT(!"Invalid keyword");                                                                  \
+        break;                                                                                       \
+    }
+
+__declspec(noinline) void ebpf_ext_log_message_guid_status(
+    ebpf_ext_tracelog_level_t trace_level,
+    ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    _In_ const GUID* guid,
+    NTSTATUS status)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, keyword, message, *guid, status);
+        break;
+    CASE_CRITICAL:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_CRITICAL, keyword, message, *guid, status);
+        break;
+    CASE_LEVEL_ERROR:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_ERROR, keyword, message, *guid, status);
+        break;
+    CASE_WARNING:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_WARNING, keyword, message, *guid, status);
+        break;
+    CASE_INFO:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_INFO, keyword, message, *guid, status);
+        break;
+    CASE_VERBOSE:
+        EBPF_EXT_LOG_MESSAGE_GUID_STATUS_KEYWORD_SWITCH(LEVEL_VERBOSE, keyword, message, *guid, status);
+        break;
+    default:
+        ASSERT(!"Invalid trace level");
+        break;
+    }
+}
+
+#pragma warning(pop)

--- a/sys/ebpf_extension_common_km.vcxproj
+++ b/sys/ebpf_extension_common_km.vcxproj
@@ -132,9 +132,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\ebpf_ext_rundown.c" />
+    <ClCompile Include="..\src\ebpf_ext_tracelog.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\ebpf_ext_rundown.h" />
+    <ClInclude Include="..\include\ebpf_ext_tracelog.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tests/ebpf_ext_rundown_test.cpp
+++ b/tests/ebpf_ext_rundown_test.cpp
@@ -4,6 +4,13 @@
 #include <catch2/catch_all.hpp>
 
 #include "ebpf_ext_rundown.h"
+#include "ebpf_ext_tracelog.h"
+
+TRACELOGGING_DEFINE_PROVIDER(
+    ebpf_ext_tracelog_provider,
+    "EbpfExtTestProvider",
+    // {d15cc421-e9e4-459b-87a6-b45b7d84e9a8}
+    (0xd15cc421, 0xe9e4, 0x459b, 0x87, 0xa6, 0xb4, 0x5b, 0x7d, 0x84, 0xe9, 0xa8));
 
 #include <thread>
 
@@ -108,4 +115,24 @@ TEST_CASE("multiple_enter_leave", "[rundown]")
     waiter.join();
 
     REQUIRE(wait_completed == true);
+}
+
+TEST_CASE("rundown_tracelog", "[rundown]")
+{
+    // Enable tracelogging to verify that events are being logged.
+    ebpf_ext_trace_initiate();
+    usersim_trace_logging_set_enabled(true, EBPF_EXT_TRACELOG_LEVEL_VERBOSE, 0xFFFF);
+
+    ebpf_ext_hook_rundown_t rundown = {};
+    ebpf_ext_init_rundown(&rundown);
+
+    bool acquired = ebpf_ext_enter_rundown(&rundown);
+    REQUIRE(acquired == true);
+    ebpf_ext_leave_rundown(&rundown);
+
+    ebpf_ext_wait_for_rundown(&rundown);
+    REQUIRE(rundown.rundown_occurred == true);
+
+    usersim_trace_logging_set_enabled(false, 0, 0);
+    ebpf_ext_trace_terminate();
 }

--- a/user/ebpf_extension_common_um.vcxproj
+++ b/user/ebpf_extension_common_um.vcxproj
@@ -117,9 +117,15 @@
       <CompileAs Condition="'$(Configuration)'=='FuzzerDebug'">CompileAsC</CompileAs>
       <CompileAs Condition="'$(Configuration)'=='Release'">CompileAsC</CompileAs>
     </ClCompile>
+    <ClCompile Include="..\src\ebpf_ext_tracelog.c">
+      <CompileAs Condition="'$(Configuration)'=='Debug'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)'=='FuzzerDebug'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)'=='Release'">CompileAsC</CompileAs>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\ebpf_ext_rundown.h" />
+    <ClInclude Include="..\include\ebpf_ext_tracelog.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This pull request adds tracing/logging support to the eBPF extension rundown logic, allowing for better observability and debugging. The most important changes include integrating trace logging in the rundown code, updating project files to include the new tracing implementation, and adding a new test to verify trace logging functionality.

**Tracing/logging integration:**

* Added calls to `EBPF_EXT_LOG_ENTRY()` and `EBPF_EXT_LOG_EXIT()` in `ebpf_ext_init_rundown` and `ebpf_ext_wait_for_rundown` in `src/ebpf_ext_rundown.c`, and included the new `ebpf_ext_tracelog.h` header.

**Project file updates:**

* Added `ebpf_ext_tracelog.c` and `ebpf_ext_tracelog.h` to both kernel-mode (`sys/ebpf_extension_common_km.vcxproj`) and user-mode (`user/ebpf_extension_common_um.vcxproj`) project files to ensure the tracing code is compiled and included in builds. [[1]](diffhunk://#diff-27dee8616ad6234163a24372f401e6e732aa97f534f731cf36a516a2a59aee0fR135-R139) [[2]](diffhunk://#diff-cd2913e50467c7888a6464e167392b2b924d4f2965648092e8d5f7346ec6b2d6R120-R128)

**Testing enhancements:**

* In the test suite, included `ebpf_ext_tracelog.h` and defined a trace logging provider in `tests/ebpf_ext_rundown_test.cpp`.
* Added a new test case `rundown_tracelog` to verify that trace logging is enabled and events are logged during rundown operations.